### PR TITLE
Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "atom-language-pawn",
+  "name": "language-pawn",
   "main": "./lib/atom-language-pawn",
   "version": "0.2.0",
   "description": "Pawn language support for Atom",


### PR DESCRIPTION
This changes the package name to "language-pawn" for consistency with
other atom packages (package names usually don't start with "atom-").
